### PR TITLE
A showcase test that uses XSD generator to produce the desried output

### DIFF
--- a/xmla/ws/jakarta.model/pom.xml
+++ b/xmla/ws/jakarta.model/pom.xml
@@ -11,16 +11,15 @@
 **********************************************************************/
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.eclipse.daanse</groupId>
-    <artifactId>org.eclipse.daanse.xmla.ws</artifactId>
-    <version>${revision}</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
-  <artifactId>org.eclipse.daanse.xmla.ws.jakarta.model</artifactId>
-  	<dependencies>
-
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.daanse</groupId>
+		<artifactId>org.eclipse.daanse.xmla.ws</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<artifactId>org.eclipse.daanse.xmla.ws.jakarta.model</artifactId>
+	<dependencies>
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.annotation</artifactId>
@@ -29,5 +28,39 @@
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/xsd</directory>
+				<targetPath>META-INF/JAXB/xsd/</targetPath>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jaxb2-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>xsd-to-java</id>
+						<goals>
+							<goal>xjc</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<xsdPathWithinArtifact>META-INF/JAXB/xsd</xsdPathWithinArtifact>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/xmla/ws/jakarta.model/src/main/xsd/discover.xsd
+++ b/xmla/ws/jakarta.model/src/main/xsd/discover.xsd
@@ -1,0 +1,20 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns="urn:schemas-microsoft-com:xml-analysis"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:rowset="urn:schemas-microsoft-com:xml-analysis:rowset"
+	targetNamespace="urn:schemas-microsoft-com:xml-analysis"
+	elementFormDefault="qualified">
+	<xsd:import namespace="urn:schemas-microsoft-com:xml-analysis:rowset" schemaLocation="rowset.xsd"/>
+	<xsd:element name="DiscoverResponse">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="return" type="Return" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:complexType name="Return">
+		<xsd:sequence>
+			<xsd:element ref="rowset:root"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/xmla/ws/jakarta.model/src/main/xsd/rowset.xsd
+++ b/xmla/ws/jakarta.model/src/main/xsd/rowset.xsd
@@ -1,0 +1,37 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns="urn:schemas-microsoft-com:xml-analysis:rowset"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:sql="urn:schemas-microsoft-com:xml-sql"
+	targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset"
+	elementFormDefault="qualified">
+	<xsd:element name="root">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="row" type="row" minOccurs="0"
+					maxOccurs="unbounded" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:simpleType name="uuid">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern
+				value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}" />
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="row">
+		<xsd:sequence>
+			<xsd:element sql:field="PropertyName" name="PropertyName"
+				type="xsd:string" />
+			<xsd:element sql:field="PropertyDescription"
+				name="PropertyDescription" type="xsd:string" />
+			<xsd:element sql:field="PropertyType" name="PropertyType"
+				type="xsd:string" />
+			<xsd:element sql:field="PropertyAccessType"
+				name="PropertyAccessType" type="xsd:string" />
+			<xsd:element sql:field="IsRequired" name="IsRequired"
+				type="xsd:boolean" />
+			<xsd:element sql:field="Value" name="Value"
+				type="xsd:string" />
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/xmla/ws/jakarta.model/src/test/java/org/eclipse/daanse/xmla/ws/jakarta/model/test/SerializeTest.java
+++ b/xmla/ws/jakarta.model/src/test/java/org/eclipse/daanse/xmla/ws/jakarta/model/test/SerializeTest.java
@@ -1,0 +1,114 @@
+package org.eclipse.daanse.xmla.ws.jakarta.model.test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import com.microsoft.schemas.xml_analysis.DiscoverResponse;
+import com.microsoft.schemas.xml_analysis.Return;
+import com.microsoft.schemas.xml_analysis.rowset.Root;
+import com.microsoft.schemas.xml_analysis.rowset.Row;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.MarshalException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.PropertyException;
+
+public class SerializeTest {
+	static SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+	static JAXBContext jaxbContext;
+
+	static {
+		try {
+			jaxbContext = JAXBContext.newInstance(Root.class, Row.class, DiscoverResponse.class);
+		} catch (JAXBException e) {
+			throw new AssertionError(e);
+		}
+	}
+
+	@Test
+	public void testRowset() throws Exception {
+		Root root = new Root();
+		Row row = new Row();
+		row.setPropertyName("DbpropMsmdSubqueries");
+		row.setPropertyDescription("An enumeration value that determines the behavior of subqueries.");
+		row.setPropertyType("Integer");
+		row.setPropertyAccessType("ReadWrite");
+		row.setIsRequired(false);
+		row.setValue("1");
+		root.getRow().add(row);
+
+		Marshaller marshaller = createMarshaller("rowset.xsd");
+		System.out.println("Will marshall and validate object");
+		marshaller.marshal(root, System.out);
+		assertThrows(MarshalException.class, () -> {
+			Root invalidRoot = new Root();
+			Row invalidRow = new Row();
+			invalidRow.setPropertyName("DbpropMsmdSubqueries");
+			invalidRoot.getRow().add(invalidRow);
+			marshaller.marshal(invalidRoot, OutputStream.nullOutputStream());
+		});
+	}
+
+	@Test
+	public void testDiscoverResponse() throws Exception {
+		DiscoverResponse response = new DiscoverResponse();
+		Return value = new Return();
+		response.setReturn(value);
+		Root root = new Root();
+		Row row = new Row();
+		row.setPropertyName("DbpropMsmdSubqueries");
+		row.setPropertyDescription("An enumeration value that determines the behavior of subqueries.");
+		row.setPropertyType("Integer");
+		row.setPropertyAccessType("ReadWrite");
+		row.setIsRequired(false);
+		row.setValue("1");
+		root.getRow().add(row);
+		value.setRoot(root);
+		Marshaller marshaller = createMarshaller("discover.xsd");
+		System.out.println("Will marshall and validate object");
+		marshaller.marshal(response, System.out);
+	}
+
+	private Marshaller createMarshaller(String name) throws SAXException, JAXBException, PropertyException {
+		Schema schema = getSchema(name);
+		Marshaller marshaller = jaxbContext.createMarshaller();
+		marshaller.setSchema(schema);
+		marshaller.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.toString());
+		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+		try {
+			marshaller.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new NamespacePrefixMapper() {
+
+				@Override
+				public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+					if ("urn:schemas-microsoft-com:xml-analysis".equals(namespaceUri)) {
+						return requirePrefix ? "analysis" : null;
+					}
+					if ("urn:schemas-microsoft-com:xml-analysis:rowset".equals(namespaceUri)) {
+						return requirePrefix ? "rowset" : null;
+					}
+					return suggestion;
+				}
+
+			});
+		} catch (PropertyException e) {
+			// In case another JAXB implementation is used
+		}
+		return marshaller;
+	}
+
+	public static Schema getSchema(String name) throws SAXException {
+		return schemaFactory.newSchema(SerializeTest.class.getResource("/META-INF/JAXB/xsd/" + name));
+	}
+
+}


### PR DESCRIPTION
This do the following:
- use the xsd from the example request
- generates java classes from the xsd
- add a testcase that generates two objects (one valid and an invalid one according to the schema) and validates them against the previous mentioned schema while marshaling them to a stream